### PR TITLE
Update doorbell.yaml to replace restore_state with restore_mode

### DIFF
--- a/doorbell.yaml
+++ b/doorbell.yaml
@@ -79,7 +79,7 @@ switch:
   - platform: template
     name: Doorbell Chime Active
     id: chime_active
-    restore_state: false
+    restore_mode: disabled
     turn_on_action:
       - globals.set:
           id: chime


### PR DESCRIPTION
ESPHome 2023.7.0 - 19th July 2023:
Remove template switch restore_state [esphome#5106](https://github.com/esphome/esphome/pull/5106) by @jesserockz (breaking-change)

This commit replaces the now removed template switch restore_state with restore_mode; defaults to disabled.