### PR TITLE
Remove "Doorbell" from entity names, change relay to a regular entity

### DIFF
--- a/smart-doorbell.yaml
+++ b/smart-doorbell.yaml
@@ -19,7 +19,7 @@ ota:
 
 wifi:
   # remove leading '#' and fill in your wifi details
-#  ssid: !secret wifi_ssid 
+#  ssid: !secret wifi_ssid
 #  password: !secret wifi_password
   ap:
   # Enable fallback hotspot (captive portal) in case wifi connection fails
@@ -52,44 +52,43 @@ dashboard_import:
 time:
   - platform: homeassistant
     id: homeassistant_time
- 
+
 text_sensor:
   - platform: version
-    name: Doorbell ESPHome Version
+    name: ESPHome Version
   - platform: wifi_info
     ip_address:
-      name: Doorbell IP
+      name: IP
     ssid:
-      name: Doorbell SSID
+      name: SSID
     bssid:
-      name: Doorbell BSSID
- 
+      name: BSSID
+
 sensor:
   - platform: uptime
-    name: Doorbell Uptime
+    name: Uptime
   - platform: wifi_signal
-    name: Doorbell WiFi Signal
+    name: WiFi Signal
     update_interval: 60s
- 
+
 globals:
   - id: chime
     type: bool
     restore_value: true
     initial_value: 'true'
- 
+
 switch:
   - platform: gpio
     pin:
       number: GPIO5
       inverted: false
-    name: "Doorbell Relay"
+    name: Relay
     id: relay
-    internal: true
     icon: mdi:alarm-bell
   - platform: restart
-    name: "Doorbell Restart"
+    name: Restart
   - platform: template
-    name: Doorbell Chime Active
+    name: Chime Active
     id: chime_active
     restore_mode: disabled
     turn_on_action:
@@ -102,14 +101,14 @@ switch:
           value: 'false'
     lambda: |-
       return id(chime);
-     
+
 binary_sensor:
   - platform: gpio
     pin:
       number: GPIO4
       mode: INPUT_PULLUP
       inverted: true
-    name: "Doorbell"
+    name: Button
     filters:
       # Small filter, to debounce the button press.
       - delayed_on: 25ms
@@ -124,7 +123,7 @@ binary_sensor:
             - switch.turn_on: relay
     on_release:
       # On release, turn of the chime.
-      - switch.turn_off: relay        
- 
+      - switch.turn_off: relay
+
   - platform: status
-    name: "Status Doorbell"
+    name: Status


### PR DESCRIPTION
Because of how Home Assistant creates entities from ESPHome devices, a sensor that in ESPHome is named "Doorbell chime active", when set up with a device simply called "Doorbell", will have its entity named "switch.doorbell_doorbell_chime_active", which is not ideal. By removing "Doorbell" as a prefix for these components, the naming convention inside HA works better.

Secondly, by making the relay component not internal, it can be used with automations for other things. One example is setting up a siren for the alarm integration, or a short beep to indicate something else is wrong, like a water leak sensor, or an AC turned on with an open window/door. 