### PR TITLE
Compatibility with ESPHome Device Builder Version: 2025.2.0 and above

### DIFF
--- a/dingdong.yaml
+++ b/dingdong.yaml
@@ -1,11 +1,12 @@
 esphome:
   name: dingdong
-  platform: ESP8266
-  board: d1_mini
   project:
     name: zuidwijk.doorbell
     version: "2.0"
-    
+
+esp8266:
+  board: d1_mini
+
 wifi:
   networks:
     - ssid: !secret wifi_ssid

--- a/doorbell-dingdong.yaml
+++ b/doorbell-dingdong.yaml
@@ -1,11 +1,12 @@
 esphome:
   name: doorbell
-  platform: ESP8266
-  board: d1_mini
   project:
     name: zuidwijk.doorbell
     version: "2.0"
- 
+
+esp8266:
+  board: d1_mini
+
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password

--- a/doorbell-ring.yaml
+++ b/doorbell-ring.yaml
@@ -1,11 +1,12 @@
 esphome:
   name: doorbell
-  platform: ESP8266
-  board: d1_mini
   project:
     name: zuidwijk.doorbell
     version: "2.0"
- 
+
+esp8266:
+  board: d1_mini
+
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password

--- a/doorbell.yaml
+++ b/doorbell.yaml
@@ -4,12 +4,13 @@ substitutions:
   
 esphome:
   name: ${device_name}
-  platform: ESP8266
-  board: d1_mini
   project:
     name: zuidwijk.doorbell
     version: "2.0"
- 
+
+esp8266:
+  board: d1_mini
+
 wifi:
   # remove leading '#' and fill in your wifi details
 #  ssid: !secret wifi_ssid 

--- a/smartdoorbell.yaml
+++ b/smartdoorbell.yaml
@@ -1,10 +1,11 @@
 esphome:
   name: smartdoorbell
-  platform: ESP8266
-  board: d1_mini
   project:
     name: zuidwijk.doorbell
     version: "2.0"
+
+esp8266:
+  board: d1_mini
 
 dashboard_import:
   package_import_url: github://zuidwijk/doorbell/smartdoorbell.yaml


### PR DESCRIPTION
This PR creates the compatibility for the latest ESPHome Device Builder Version and above.

Reference: https://esphome.io/components/esp8266.html

**Added:**
- nothing

**Deleted:**
- nothing

**Changed:**
- moved platform and board key from esphome section to the esp8266 section